### PR TITLE
Clean up exporter

### DIFF
--- a/gcp/export_region_function/main.py
+++ b/gcp/export_region_function/main.py
@@ -102,8 +102,7 @@ def export_region(request: Request):
             num_timesteps=num_timesteps,
         ).export(
             dest_bucket=dest_bucket,
-            dest_folder=dest_folder,
-            model_name=model_name,
+            dest_path=f"{model_name}/{dest_folder}",
             region_bbox=bbox,
             start_date=start_date,
             metres_per_polygon=50000,

--- a/scripts/export_region.py
+++ b/scripts/export_region.py
@@ -15,5 +15,5 @@ if __name__ == "__main__":
     dest_folder = "<your destination folder>"
     bounding_box = BoundingBox(0, 1, 0, 1)
     RegionExporter().export(
-        metres_per_polygon=None, dest_folder=dest_folder, region_bbox=bounding_box
+        metres_per_polygon=None, dest_path=dest_folder, region_bbox=bounding_box
     )


### PR DESCRIPTION
- Removes deprecated `season` code
- Removes model_name as parameter for RegionalExporter.export() in favor of dest_path
- Adds a couple comments