### PR TITLE
Notebook for calculating area estimates from a crop mask and reference sample

### DIFF
--- a/notebooks/crop_area_estimation.ipynb
+++ b/notebooks/crop_area_estimation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c333c361",
+   "id": "25bef116",
    "metadata": {},
    "source": [
     "## Estimate crop area based on crop mask\n",
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d8e7086",
+   "id": "81caa17e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "875dc1b5",
+   "id": "b618e90c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,14 +48,14 @@
     "### Set the custom paths that will be used for your analysis ###\n",
     "### This should be the only code you need to change          ###\n",
     "################################################################\n",
-    "mask_path = '/Users/hkerner/data/china/binary_masks/epsg32652_HLJ_2016.tif'\n",
-    "ceo_set1_path = '/Users/hkerner/src/china-crop-mask/area_estimation/reference_samples/labeled_ceo/ceo-Heilongjiang-2016-(Set-2)---v2-sample-data-2022-01-21.csv'\n",
-    "ceo_set2_path = '/Users/hkerner/src/china-crop-mask/area_estimation/reference_samples/labeled_ceo/ceo-Heilongjiang-2016-(Set-2)---v2-sample-data-2022-01-21.csv'"
+    "mask_path = '/gpfs/data1/cmongp1/barker/binary_masks/reprojected/epsg32652_HLJ_2019.tif'\n",
+    "ceo_set1_path = '/gpfs/data1/cmongp1/barker/labeled_ceo/ceo-HLJ-2019-(Set-1)---v3-sample-data-2022-01-21.csv'\n",
+    "ceo_set2_path = '/gpfs/data1/cmongp1/barker/labeled_ceo/ceo-HLJ-2019-(Set-2)---v3-sample-data-2022-01-21.csv'"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c921bff3",
+   "id": "1a217fde",
    "metadata": {},
    "source": [
     "## 1. Load the crop mask"
@@ -64,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14ad79ca",
+   "id": "328c7ae5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ad8cdff",
+   "id": "e5027742",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28f13e66",
+   "id": "ef46aa79",
    "metadata": {},
    "source": [
     "## 2. Calculate the mapped area for each class"
@@ -106,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8d09a20",
+   "id": "a7443f15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af5e29a5",
+   "id": "7d3431d6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "992b463b",
+   "id": "75ad5970",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4176a012",
+   "id": "5fb92b4d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79c423b8",
+   "id": "51965a24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0120fd7",
+   "id": "d6f7e467",
    "metadata": {},
    "source": [
     "## 3. Load the labeled reference samples\n",
@@ -185,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "383188f9",
+   "id": "6089dbfc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c818dfae",
+   "id": "8bd57bc5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "716b7df4",
+   "id": "5312ba11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,18 +222,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "173fe924",
+   "id": "f21b959c",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Convert the pandas dataframe to a geodataframe\n",
-    "ceo_agree_geom = gpd.GeoDataFrame(ceo_agree, geometry=gpd.points_from_xy(ceo_agree.lon, ceo_agree.lat, crs='EPSG:4326'))"
+    "ceo_agree_geom = gpd.GeoDataFrame(ceo_agree, geometry=gpd.points_from_xy(ceo_agree.lon, ceo_agree.lat), crs='EPSG:4326')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a436f57b",
+   "id": "b63c927d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31b2188f",
+   "id": "961dddd2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69064fac",
+   "id": "4e618d3b",
    "metadata": {},
    "source": [
     "## 4. Get the mapped class for each of the reference samples"
@@ -264,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3affebb1",
+   "id": "14580b99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d6798d4",
+   "id": "04b9b173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c5f51fb",
+   "id": "7adf9f97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "541591ce",
+   "id": "fb2413eb",
    "metadata": {},
    "source": [
     "## 5. Compute the confusion matrix between the mapped classes and reference labels"
@@ -307,7 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d7ae8fd",
+   "id": "ba97bbb5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef273899",
+   "id": "b317a36e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e9d04ef",
+   "id": "6d12cba4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +348,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f04d2bdb",
+   "id": "478c620f",
    "metadata": {},
    "source": [
     "## 6. Adjust mapped area using confusion matrix to compute area estimates"
@@ -356,7 +356,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e1f87ff1",
+   "id": "4fc0242d",
    "metadata": {},
    "source": [
     "$W_h$ is the proportion of mapped area for each class "
@@ -365,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25413db1",
+   "id": "44c324ae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f9d2bc03",
+   "id": "417d3cb2",
    "metadata": {},
    "source": [
     "Compute the fraction of the proportional area of each class that was mapped as each category in the confusion matrix"
@@ -387,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9903d1d0",
+   "id": "bd3b7670",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,7 +401,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecdbea25",
+   "id": "9c75bf8f",
    "metadata": {},
    "source": [
     "$U_i$ is the user's accuracy (i.e., precision) for each mapped class. We calculate it here in terms of proportion of area computed in the last cell."
@@ -410,7 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3464d8f5",
+   "id": "76fa03a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,7 +423,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb9db289",
+   "id": "2c052246",
    "metadata": {},
    "source": [
     "$V(U_i)$ is the estimated variance of user accuracy for each mapped class."
@@ -432,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb93c95b",
+   "id": "0d58b191",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce58e47f",
+   "id": "6e2d6b16",
    "metadata": {},
    "source": [
     "$S(U_i)$ is the estimated standard error of user accuracy for each mapped class."
@@ -454,7 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "161945fc",
+   "id": "e4c6330d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69157be1",
+   "id": "56cac48e",
    "metadata": {},
    "source": [
     "Get the 95% confidence interval for User's accuracy"
@@ -476,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "605b6dcd",
+   "id": "44e37f5f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +489,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9ffefeaa",
+   "id": "81fcfc1c",
    "metadata": {},
    "source": [
     "$P$ is the producer's accuracy (i.e., recall). We calculate it here in terms of proportion of area."
@@ -498,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9bc08f2",
+   "id": "60857718",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +511,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6acf266",
+   "id": "78580033",
    "metadata": {},
    "source": [
     "$N_j$ is the estimated marginal total number of pixels of each reference class $j$"
@@ -520,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7614c7d6",
+   "id": "8e3ab5e7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,7 +534,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "067e8a33",
+   "id": "4ff335be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87470961",
+   "id": "72678e8e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -564,7 +564,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1477e88",
+   "id": "54200296",
    "metadata": {},
    "source": [
     "$V(P_i)$ is the estimated variance of producer's accuracy for each mapped class."
@@ -573,7 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41705ea5",
+   "id": "5cdfe1e6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,7 +586,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f389ddf9",
+   "id": "20562ea9",
    "metadata": {},
    "source": [
     "$S(P_i)$ is the estimated standard error of producer accuracy for each mapped class."
@@ -595,7 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e93313ab",
+   "id": "294a6518",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -611,7 +611,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1235e83",
+   "id": "fd606331",
    "metadata": {},
    "source": [
     "Get the 95% confidence interval for Producer's accuracy"
@@ -620,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de8b6e40",
+   "id": "56f88562",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -633,7 +633,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14608099",
+   "id": "df8734e6",
    "metadata": {},
    "source": [
     "$O$ is the overall accuracy. We calculate it here in terms of proportion of area."
@@ -642,7 +642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8bd0c31",
+   "id": "2450ff67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -652,7 +652,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64935a9f",
+   "id": "e6886a49",
    "metadata": {},
    "source": [
     "$V(O)$ is the estimated variance of the overall accuracy"
@@ -661,7 +661,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7141543d",
+   "id": "cb8b14cd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -672,7 +672,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c5d0abba",
+   "id": "0d2b1ad3",
    "metadata": {},
    "source": [
     "$S(O)$ is the estimated standard error of the overall accuracy"
@@ -681,7 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8cc17d2b",
+   "id": "0ae08bc4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,7 +691,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9747226",
+   "id": "c0f3f37a",
    "metadata": {},
    "source": [
     "Get the 95% confidence interval for overall accuracy"
@@ -700,7 +700,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2f9249e",
+   "id": "8fef1180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +710,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74237afd",
+   "id": "a6587cfc",
    "metadata": {},
    "source": [
     "$A_{pixels}$ is the adjusted map area in units of pixels"
@@ -719,7 +719,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bdea8a49",
+   "id": "a10c564a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +732,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32c3b2c0",
+   "id": "7347e68c",
    "metadata": {},
    "source": [
     "$A_{ha}$ is the adjusted map area in units of hectares"
@@ -741,7 +741,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "676ce800",
+   "id": "6a732fca",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -754,7 +754,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff926fbc",
+   "id": "7d93e4c2",
    "metadata": {},
    "source": [
     "The following equations are used to estimate the standard error for the area. They are based on the calculations in Olofsson et al., 2014."
@@ -763,7 +763,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f20e8223",
+   "id": "7fcfeb74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -778,7 +778,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75bf4a39",
+   "id": "8913bcae",
    "metadata": {},
    "source": [
     "Multiply $S(p_k)$ by 1.96 to get the margin of error for the 95% confidence interval"
@@ -787,7 +787,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a074c771",
+   "id": "49665a5a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -801,7 +801,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "390ba5c1",
+   "id": "2a0d9369",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -814,7 +814,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dca9c4d6",
+   "id": "c439e81e",
    "metadata": {},
    "source": [
     "Summary of the final estimates of accuracy and area with standard error at 95% confidence intervals:"
@@ -823,7 +823,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1aca8fc",
+   "id": "de476540",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -847,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66710440",
+   "id": "4b832419",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -855,7 +855,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11cbe31d",
+   "id": "3e0d25f9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "630f887d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0afba4c5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12453ae5",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -877,7 +901,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
New [notebook](https://github.com/nasaharvest/crop-mask/blob/area-estimation/notebooks/crop_area_estimation.ipynb) for doing area and accuracy estimates based on the crop mask and a labeled reference sample, following best practices from [Olofsson et al., 2014](https://www.sciencedirect.com/science/article/abs/pii/S0034425714000704). 

These calculations were previously spread out between random notebooks and Excel spreadsheets 💀 
This is the first step to condense the whole process in one place to make it easier/more automated to calculate area estimates.

There shouldn't be any conflicts with anything else but tagging @ivanzvonkov as an fyi or in case you see any issues before merging to master.