### PR TITLE
disagreement notebook with mapping and user disagreement rates

### DIFF
--- a/notebooks/eva-0.5probproject.ipynb
+++ b/notebooks/eva-0.5probproject.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 2,
    "id": "bfd56b10",
    "metadata": {},
    "outputs": [],
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 3,
    "id": "c9a15508",
    "metadata": {},
    "outputs": [],
@@ -93,14 +93,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 4,
    "id": "e74c7b4a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c2b4d9704b0148459b8881c6da950280",
+       "model_id": "47e4de100ff642218432bff1e8c4542f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -118,6 +118,16 @@
     "locations = country_halfprob[[\"lat\",\"lon\"]]\n",
     "fig.add_layer(gmaps.heatmap_layer(locations))\n",
     "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c62763e",
+   "metadata": {},
+   "source": [
+    "## Tigray 2020 - 2021 Insights:\n",
+    "    \n",
+    "While there were not any stark clusters of disagreements coming from the Tigray datasets, I did find that disagreed points followed the general trend of 'harder-to-label' points. Many disagreement points resembled shrubs or had very rough/abstract edges around what could be interpreted as a farm plot. There were some terrace farming points as well, but not as many as the former two. "
    ]
   },
   {


### PR DESCRIPTION
final version of this notebook for now!

Some potential improvements for down the line:
 - global variables for subject matter experts to be used in user disagreement rate analysis
 - ability to click through individual disagreement points on the map instead of using zoom in/out feature