### PR TITLE
Freeze fsspec

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -17,3 +17,4 @@ dependencies:
           - types-python-dateutil
           - openmapflow[data]==0.2.3rc1
           - dvc[gs]
+          - fsspec==2022.11.0 # https://github.com/iterative/dvc-azure/issues/34


### PR DESCRIPTION
New version of fsspec seems to have effected the test CI script. This PR freezes the fsspec version to a prior release.