### PR TITLE
Upgrade to Python3.9

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,9 +3,8 @@ channels:
     - conda-forge
     - pytorch
 dependencies:
-    - python=3.7
+    - python=3.9
     - pip
-    - mypy=0.931
     - scikit-learn
     - cartopy
     - pytorch=1.7.1
@@ -13,8 +12,6 @@ dependencies:
           - pre-commit==2.20.0
           - pytorch-lightning==0.7.1 # lots of API changes
           - wandb
-          - types-requests
-          - types-python-dateutil
           - openmapflow[data]==0.2.3rc3
           - dvc[gs]
           - fsspec==2022.11.0 # https://github.com/iterative/dvc-azure/issues/34


### PR DESCRIPTION
Python3.7 is reaching end of life in 3 months
https://endoflife.date/python

Also removes packages which are taken care of by pre-commit