### PR TITLE
Fix Dataset Dates

### DIFF
--- a/data/datasets.dvc
+++ b/data/datasets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: a633fe9face75249d298ff3898d712df.dir
-  size: 670963535
+- md5: 8f2a10b12691a871c3dfcbb87ddbdc13.dir
+  size: 671340876
   nfiles: 40
   path: datasets

--- a/data/datasets.dvc
+++ b/data/datasets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 04b064041ad8041e4b942cf5c04fbfb5.dir
-  size: 671870974
-  nfiles: 40
+- md5: 01e751f466ca592879d6e75f053f5f94.dir
+  size: 670226599
+  nfiles: 39
   path: datasets

--- a/data/datasets.dvc
+++ b/data/datasets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 64d6110cf8e257838402c038f458a5f4.dir
-  size: 670263594
+- md5: a633fe9face75249d298ff3898d712df.dir
+  size: 670963535
   nfiles: 40
   path: datasets

--- a/data/datasets.dvc
+++ b/data/datasets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: c62a3e474557c3539e3371064bf5f30c.dir
-  size: 669317555
-  nfiles: 38
+- md5: 40dc0329d2cdde68a5986691c4c6f44e.dir
+  size: 669390168
+  nfiles: 40
   path: datasets

--- a/data/datasets.dvc
+++ b/data/datasets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 40dc0329d2cdde68a5986691c4c6f44e.dir
-  size: 669390168
+- md5: b61c852a08a4a6e50b24cf9c2e39b113.dir
+  size: 670144067
   nfiles: 40
   path: datasets

--- a/data/datasets.dvc
+++ b/data/datasets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 01e751f466ca592879d6e75f053f5f94.dir
-  size: 670226599
-  nfiles: 39
+- md5: 64d6110cf8e257838402c038f458a5f4.dir
+  size: 670263594
+  nfiles: 40
   path: datasets

--- a/data/datasets.dvc
+++ b/data/datasets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: b61c852a08a4a6e50b24cf9c2e39b113.dir
-  size: 670144067
+- md5: 04b064041ad8041e4b942cf5c04fbfb5.dir
+  size: 671870974
   nfiles: 40
   path: datasets

--- a/data/datasets.dvc
+++ b/data/datasets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: db44add22718f254286f77bdb491aa8f.dir
-  size: 670778757
-  nfiles: 40
+- md5: c62a3e474557c3539e3371064bf5f30c.dir
+  size: 669317555
+  nfiles: 38
   path: datasets

--- a/data/report.txt
+++ b/data/report.txt
@@ -366,6 +366,5 @@ eo_data_complete    47
 
 EthiopiaTigrayCorrective2020 (Timesteps: 24)
 ----------------------------------------------------------------------------
-eo_data_complete     130
-eo_data_exporting     70
-✖ training: 200 labels, but 130 features
+eo_data_complete    200
+✔ training amount: 200, positive class: 2.0%

--- a/data/report.txt
+++ b/data/report.txt
@@ -366,5 +366,6 @@ eo_data_complete    47
 
 EthiopiaTigrayCorrective2020 (Timesteps: 24)
 ----------------------------------------------------------------------------
-eo_data_exporting    200
-✖ training: 200 labels, but 0 features
+eo_data_complete     130
+eo_data_exporting     70
+✖ training: 200 labels, but 130 features

--- a/data/report.txt
+++ b/data/report.txt
@@ -341,10 +341,10 @@ eo_data_complete    12451
 
 
 
-EthiopiaTigrayGhent2021 (Timesteps: 23)
+EthiopiaTigrayGhent2021 (Timesteps: 24)
 ----------------------------------------------------------------------------
-eo_data_complete    161
-✔ validation amount: 161, positive class: 78.9%
+eo_data_exporting    161
+✖ validation: 161 labels, but 0 features
 
 
 
@@ -364,7 +364,7 @@ eo_data_complete    47
 
 
 
-EthiopiaTigrayCorrective2020 (Timesteps: 12)
+EthiopiaTigrayCorrective2020 (Timesteps: 36)
 ----------------------------------------------------------------------------
-eo_data_complete    200
-✔ training amount: 200, positive class: 2.0%
+eo_data_exporting    200
+✖ training: 200 labels, but 0 features

--- a/data/report.txt
+++ b/data/report.txt
@@ -343,9 +343,8 @@ eo_data_complete    12451
 
 EthiopiaTigrayGhent2021 (Timesteps: 24)
 ----------------------------------------------------------------------------
-eo_data_complete     139
-eo_data_exporting     22
-✖ validation: 161 labels, but 139 features
+eo_data_complete    161
+✔ validation amount: 161, positive class: 78.9%
 
 
 
@@ -367,5 +366,5 @@ eo_data_complete    47
 
 EthiopiaTigrayCorrective2020 (Timesteps: 36)
 ----------------------------------------------------------------------------
-eo_data_exporting    200
-✖ training: 200 labels, but 0 features
+eo_data_complete    200
+✔ training amount: 200, positive class: 2.0%

--- a/data/report.txt
+++ b/data/report.txt
@@ -343,8 +343,9 @@ eo_data_complete    12451
 
 EthiopiaTigrayGhent2021 (Timesteps: 24)
 ----------------------------------------------------------------------------
-eo_data_exporting    161
-✖ validation: 161 labels, but 0 features
+eo_data_complete     139
+eo_data_exporting     22
+✖ validation: 161 labels, but 139 features
 
 
 

--- a/data/report.txt
+++ b/data/report.txt
@@ -364,7 +364,7 @@ eo_data_complete    47
 
 
 
-EthiopiaTigrayCorrective2020 (Timesteps: 36)
+EthiopiaTigrayCorrective2020 (Timesteps: 24)
 ----------------------------------------------------------------------------
-eo_data_complete    200
-✔ training amount: 200, positive class: 2.0%
+eo_data_exporting    200
+✖ training: 200 labels, but 0 features

--- a/datasets.py
+++ b/datasets.py
@@ -60,7 +60,7 @@ class EthiopiaTigrayCorrective2020(LabeledDataset):
         df = pd.read_csv(raw_dir / "Ethiopia_Tigray_Corrective_2020.csv")
         df.rename(columns={"latitude": LAT, "longitude": LON}, inplace=True)
         df[CLASS_PROB] = (df["Wrong value"] == 0).astype(int)
-        df[START], df[END] = date(2020, 1, 1), date(2022, 12, 31)
+        df[START], df[END] = date(2020, 1, 1), date(2021, 12, 31)
         df[SUBSET] = "training"
         return df
 

--- a/datasets.py
+++ b/datasets.py
@@ -60,7 +60,7 @@ class EthiopiaTigrayCorrective2020(LabeledDataset):
         df = pd.read_csv(raw_dir / "Ethiopia_Tigray_Corrective_2020.csv")
         df.rename(columns={"latitude": LAT, "longitude": LON}, inplace=True)
         df[CLASS_PROB] = (df["Wrong value"] == 0).astype(int)
-        df[START], df[END] = date(2020, 2, 1), date(2021, 2, 1)
+        df[START], df[END] = date(2020, 1, 1), date(2022, 12, 31)
         df[SUBSET] = "training"
         return df
 
@@ -76,7 +76,7 @@ class EthiopiaTigrayGhent2021(LabeledDataset):
                 "Crop/Non-Crop": CLASS_PROB,
             }
         )
-        df[START], df[END] = date(2021, 1, 1), date(2022, 11, 30)
+        df[START], df[END] = date(2021, 1, 1), date(2022, 12, 31)
         df[SUBSET] = "validation"
         return df
 


### PR DESCRIPTION
1. Update 2020 corrective Ethiopia Tigray dataset start and end dates (24 months).
2. Update 2021 Ghent University Ethiopia dataset end date (2022-12-31)
3. Deleted above datasets from `data/datasets` and added updated `datasets.dvc` for regeneration of the two