### PR TITLE
Fix set NODATA and projection when clipping

### DIFF
--- a/src/area_utils.py
+++ b/src/area_utils.py
@@ -134,14 +134,21 @@ def load_raster(
                 \n You need to project the map to the local UTM Zone \
                 (EPSG:XXXXX)."""
             )
+    
             t_srs = input("Input EPSG Code; EPSG:XXXX:")
-            options = {"dstSRS": f"EPSG:{t_srs}", "dstNodata": 255}
-            gdal.Warp(f"prj_{in_raster_basename}", in_raster_basename, **options)
-            in_raster = f"prj_{in_raster_basename}"
-            return clip_raster(in_raster, boundary)
+            options = gdal.WarpOptions(dstSRS=f'EPSG:{t_srs}', dstNodata=255)
+            output_raster = f"prj_{in_raster_basename}"
+            gdal.Warp(output_raster, in_raster, options=options)
+            in_raster = output_raster
+
         else:
-            print("Map CRS is %s. Loading map into memory." % src.crs)
-            return clip_raster(in_raster, boundary)
+            print("Map CRS is %s. Setting nodata value to 255." % src.crs)
+            options = gdal.WarpOptions(dstNodata=255)
+            output_raster = f"nodata_{in_raster_basename}"
+            gdal.Warp(output_raster, in_raster, options=options)
+            in_raster = output_raster
+        
+        return clip_raster(in_raster, boundary)
 
 
 def binarize(

--- a/src/area_utils.py
+++ b/src/area_utils.py
@@ -134,9 +134,9 @@ def load_raster(
                 \n You need to project the map to the local UTM Zone \
                 (EPSG:XXXXX)."""
             )
-    
+
             t_srs = input("Input EPSG Code; EPSG:XXXX:")
-            options = gdal.WarpOptions(dstSRS=f'EPSG:{t_srs}', dstNodata=255)
+            options = gdal.WarpOptions(dstSRS=f"EPSG:{t_srs}", dstNodata=255)
             output_raster = f"prj_{in_raster_basename}"
             gdal.Warp(output_raster, in_raster, options=options)
             in_raster = output_raster
@@ -147,7 +147,7 @@ def load_raster(
             output_raster = f"nodata_{in_raster_basename}"
             gdal.Warp(output_raster, in_raster, options=options)
             in_raster = output_raster
-        
+
         return clip_raster(in_raster, boundary)
 
 


### PR DESCRIPTION
### Issue Description

In the area estimation notebook, when clipping the cropmask to the Regions of Interest (RoIs), we want pixels to be 0 for non-crop, 1 for crop, and 255 for NODATA. However, the current `load_raster` function does not set NODATA to 255 and returns errors if the input raster has the `EPSG:4326` projection.

### Fixes
- [x] In the `load_raster` function, added logic to set NODATA value to 255 for all rasters.
- [x] Ensured proper handling of rasters with `EPSG:4326` projection by reprojecting to a user-specified EPSG code.
- [x] Used `gdal.Warp` to apply NODATA values consistently and handle reprojection.


