### PR TITLE
Fixed bug that broke area estimate notebooks

### DIFF
--- a/src/area_utils.py
+++ b/src/area_utils.py
@@ -316,7 +316,9 @@ def reference_sample_agree(
         px, py = transform.rowcol(meta["transform"], lat, lon)
 
         try:
-            ceo_agree_geom.loc[r, "Mapped class"] = int(binary_map[px, py])
+
+            ceo_agree_geom.loc[r, "Mapped class"] = int(binary_map[int(px), int(py)])
+
             if (
                 row[label_question].lower() == "cropland"
                 or row[label_question].lower() == "crop"


### PR DESCRIPTION
## Description
Cast points to int so they can be used as indices into the array properly; `px` and `py` were being inferred as doubles. 

## Validation
Tested on [multi_roi_multi_period_area_estimate branch](https://github.com/nasaharvest/crop-mask/tree/multi_roi_multi_period_area_estimate) locally and on colab notebook. The issues were happening on my local version of python 3.12.4 and on Colab's 3.10.12.